### PR TITLE
Fix Travis in several ways

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
 
 # command to run tests
 script:
+  # Run unittests
+  - python -m unittest discover test/
   - export WLLVM_HOME=`pwd`
   - export APACHE_VER=2.4.18
   # build apache with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,18 @@ python:
 # command to install dependencies
 install:
   - sudo apt-get update
-  # to install wllvm
-  - sudo apt-get install -y python-pip
   # apache prerequisites
   - sudo apt-get install  -y libapr1-dev libaprutil1-dev
   # for the clang build  
   - sudo apt-get install  -y llvm-3.5 clang-3.5
   # dragonegg prereqs. dragonegg and llvm-gcc use llvm 3.3
   - sudo apt-get install  -y llvm-3.3 llvm-gcc-4.7
-  - sudo pip install -e .
+  # Install wllvm
+  # Report the version of pip being used for debugging purposes.
+  # It should report the site-packages directory and the version
+  # of python it is working with.
+  - pip --version
+  - pip install -e .
   - export WLLVM_HOME=`pwd`
   - export APACHE_VER=2.4.18
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ install:
   # of python it is working with.
   - pip --version
   - pip install -e .
-  - export WLLVM_HOME=`pwd`
-  - export APACHE_VER=2.4.18
 
 
 # command to run tests
 script:
+  - export WLLVM_HOME=`pwd`
+  - export APACHE_VER=2.4.18
   # build apache with clang
   - ${WLLVM_HOME}/.travis/apache_clang.sh
   # build apache with gcc and dragonegg

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: required
 dist: trusty
 
 python:
+  - "3.5"
+  - "3.4"
   - "3.3"
   - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 python:
   - "3.3"
   - "2.7"
-  - "2.6"
 
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 # command to run tests
 script:
   # Run unittests
-  - python -m unittest discover test/
+  - python -m unittest discover test/ || exit 1
   - export WLLVM_HOME=`pwd`
   - export APACHE_VER=2.4.18
   # build apache with clang

--- a/.travis/apache_clang.sh
+++ b/.travis/apache_clang.sh
@@ -7,6 +7,8 @@ export PATH=/usr/lib/llvm-3.5/bin:${PATH}
 export LLVM_COMPILER=clang
 export WLLVM_OUTPUT=WARNING
 
+wllvm-sanity-checker
+
 wget https://archive.apache.org/dist/httpd/httpd-${APACHE_VER}.tar.gz
 
 tar xfz httpd-${APACHE_VER}.tar.gz

--- a/.travis/apache_dragonegg.sh
+++ b/.travis/apache_dragonegg.sh
@@ -11,6 +11,8 @@ export LLVM_DRAGONEGG_PLUGIN=/usr/lib/gcc/x86_64-linux-gnu/4.7/plugin/dragonegg.
 
 export WLLVM_OUTPUT=WARNING
 
+wllvm-sanity-checker
+
 wget https://archive.apache.org/dist/httpd/httpd-${APACHE_VER}.tar.gz
 
 

--- a/wllvm/checker.py
+++ b/wllvm/checker.py
@@ -6,11 +6,13 @@ environment to see if it makes sense from the
 wllvm point of view. Useful first step in trying to
 debug a failure.
 """
+from __future__ import print_function
 
 import sys
 import os
 import subprocess as sp
 import errno
+
 
 explain_LLVM_COMPILER = """
 
@@ -91,7 +93,7 @@ class Checker(object):
         """
 
         if not self.checkOS():
-            print 'I do not think we support your OS. Sorry.'
+            print('I do not think we support your OS. Sorry.')
             return 1
 
         success = self.checkCompiler()
@@ -152,18 +154,18 @@ class Checker(object):
         plugin = os.getenv('LLVM_DRAGONEGG_PLUGIN')
 
         if not plugin:
-            print explain_LLVM_DRAGONEGG_PLUGIN
+            print(explain_LLVM_DRAGONEGG_PLUGIN)
             return False
 
         if os.path.isfile(plugin):
             try:
                 open(plugin)
             except IOError as e:
-                print "Unable to open {0}: {1}".format(plugin, str(e))
+                print("Unable to open {0}: {1}".format(plugin, str(e)))
             else:
                 return True
         else:
-            print "Could not find {0}".format(plugin)
+            print("Could not find {0}".format(plugin))
             return False
 
 
@@ -172,16 +174,16 @@ class Checker(object):
         (code, comment) = self.checkSwitch()
 
         if code == 0:
-            print comment
+            print(comment)
             return False
         elif code == 1:
-            print comment
+            print(comment)
             return self.checkClang()
         elif code == 2:
-            print comment
+            print(comment)
             return self.checkDragonegg()
         else:
-            print 'Insane'
+            print('Insane')
             return False
 
 
@@ -192,21 +194,21 @@ class Checker(object):
         (cxxOk, cxxVersion) = self.checkExecutable(cxx)
 
         if not ccOk:
-            print 'The C compiler {0} was not found or not executable.\nBetter not try using wllvm!\n'.format(cc)
+            print('The C compiler {0} was not found or not executable.\nBetter not try using wllvm!\n'.format(cc))
         else:
-            print 'The C compiler {0} is:\n\n{1}\n'.format(cc, extractLine(ccVersion, 0))
+            print('The C compiler {0} is:\n\n{1}\n'.format(cc, extractLine(ccVersion, 0)))
 
         if not cxxOk:
-            print 'The CXX compiler {0} was not found or not executable.\nBetter not try using wllvm++!\n'.format(cxx)
+            print('The CXX compiler {0} was not found or not executable.\nBetter not try using wllvm++!\n'.format(cxx))
         else:
-            print 'The C++ compiler {0} is:\n\n{1}\n'.format(cxx, extractLine(cxxVersion, 0))
+            print('The C++ compiler {0} is:\n\n{1}\n'.format(cxx, extractLine(cxxVersion, 0)))
 
         if not ccOk or  not cxxOk:
-            print explain_LLVM_COMPILER_PATH
+            print(explain_LLVM_COMPILER_PATH)
             if not ccOk:
-                print explain_LLVM_CC_NAME
+                print(explain_LLVM_CC_NAME)
             if not cxxOk:
-                print explain_LLVM_CXX_NAME
+                print(explain_LLVM_CXX_NAME)
 
 
 
@@ -251,16 +253,16 @@ class Checker(object):
         (arOk, arVersion) = self.checkExecutable(ar, '-version')
 
         if not linkOk:
-            print 'The bitcode linker {0} was not found or not executable.\nBetter not try using extract-bc!\n'.format(link)
-            print explain_LLVM_LINK_NAME
+            print('The bitcode linker {0} was not found or not executable.\nBetter not try using extract-bc!\n'.format(link))
+            print(explain_LLVM_LINK_NAME)
         else:
-            print 'The bitcode linker {0} is:\n\n{1}\n'.format(link, extractLine(linkVersion, 1))
+            print('The bitcode linker {0} is:\n\n{1}\n'.format(link, extractLine(linkVersion, 1)))
 
         if not arOk:
-            print 'The bitcode archiver {0} was not found or not executable.\nBetter not try using extract-bc!\n'.format(ar)
-            print explain_LLVM_AR_NAME
+            print('The bitcode archiver {0} was not found or not executable.\nBetter not try using extract-bc!\n'.format(ar))
+            print(explain_LLVM_AR_NAME)
         else:
-            print 'The bitcode archiver {0} is:\n\n{1}\n'.format(ar, extractLine(arVersion, 1))
+            print('The bitcode archiver {0} is:\n\n{1}\n'.format(ar, extractLine(arVersion, 1)))
 
 
 


### PR DESCRIPTION
This PR does the following:

* Makes the right Python version be used in each configuration.
* Run the unit tests in TravisCI
* Run the wllvm-sanity-checker during testing to check it can be executed.
* Fix `wllvm-sanity-checker` to work under Python 3
* Disable testing Python 2.6. I don't know how to run the unittests for that Python version.
* Add testing for Python 3.4 and 3.5.

@ianamason You'll see I've added a `pip --version` command. In Travis if you look at the log for each Python configuration you'll see they show different output. So now we can see that the intended python version is being used.

I'm not sure if you needed Python 2.6 support but I can't run the unit tests under that ancient version.